### PR TITLE
Bugfix for edge case in iPad: `isKeyboardVisible` incorrectly returns YES after rotation.

### DIFF
--- a/NgKeyboardTracker.podspec
+++ b/NgKeyboardTracker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'NgKeyboardTracker'
-  spec.version      = '1.0.7'
+  spec.version      = '1.0.8'
   spec.summary      = 'Objective-c library for tracking keyboard in iOS apps.'
   spec.homepage     = 'https://github.com/meiwin/NgKeyboardTracker'
   spec.author       = { 'Meiwin Fu' => 'meiwin@blockthirty.com' }

--- a/NgKeyboardTracker/NgKeyboardTracker.m
+++ b/NgKeyboardTracker/NgKeyboardTracker.m
@@ -251,6 +251,7 @@ NSString * NgAppearanceStateAsString(NgKeyboardTrackerKeyboardAppearanceState st
   [_lock unlock];
 }
 - (BOOL)isKeyboardVisible {
+  if (self.appearanceState == NgKeyboardTrackerKeyboardAppearanceStateHidden) return NO;
   CGRect intersection = CGRectIntersection([UIScreen mainScreen].bounds, _currentFrame);
   return intersection.size.height - _inputAccessoryViewHeight > 0;
 }

--- a/NgKeyboardTrackerDemo/ViewController.m
+++ b/NgKeyboardTrackerDemo/ViewController.m
@@ -131,6 +131,7 @@ NSString * DescriptionFromKeyboardTracker(NgKeyboardTracker * tracker) {
 }
 - (void)keyboardTrackerDidChangeAppearanceState:(NgKeyboardTracker *)tracker {
   _label.text = DescriptionFromKeyboardTracker(tracker);
+  [self layoutTextView];
 }
 @end
 


### PR DESCRIPTION
Bugfix for edge case in iPad: `isKeyboardVisible` incorrectly returns YES after rotation.
